### PR TITLE
fix: remove unused preamble text and close dropdown on link click

### DIFF
--- a/src/app/brostoperationer/fore-och-efter/ForeOchEfter.tsx
+++ b/src/app/brostoperationer/fore-och-efter/ForeOchEfter.tsx
@@ -51,7 +51,6 @@ const ForeOchEfter = () => {
           <Pillar>
             <SpaceContainer noPadding>
               <H1 white>{t('title')}</H1>
-              <P white>{t('preamble')}</P>
             </SpaceContainer>
           </Pillar>
         }

--- a/src/app/components/navigation/DropdownMenu.tsx
+++ b/src/app/components/navigation/DropdownMenu.tsx
@@ -110,6 +110,7 @@ export const DropdownMenu: React.FC = () => {
                     href={href}
                     className={'hover:text-gold transition-colors duration-300'}
                     tabIndex={activeLink === id ? 0 : -1}
+                    onClick={() => setIsOpen(false)}
                   >
                     {text}
                   </Link>


### PR DESCRIPTION
- Add onClick to sub menu links to close menu
- Remove missing translation